### PR TITLE
Previous Word Navigation button logic implimentation.

### DIFF
--- a/IELTS/Components/Pages/Vocabulary.razor
+++ b/IELTS/Components/Pages/Vocabulary.razor
@@ -17,7 +17,7 @@
     else
     {
         var word = wordMeanings[currentIndex];
-        <div class="card border-success mb-3" style="width: 29rem; height: 15rem">
+        <div class="card border-success mb-3" style="width: 32rem; height: 17rem">
             @if (!showDefinition)
             {
                 <div class="card-body">
@@ -55,8 +55,17 @@
                     </div>
                 </div>
                 <div class="card-footer border-success text-center" style="background-color: #dcdcdc">
-                    <button @onclick="ToggleCard" type="button"><MudIcon Icon="@Icons.Material.Filled.ChevronLeft" Style="font-size: 2rem;" /></button>
-                    <button @onclick="NextWord" type="button">Next<MudIcon Icon="@Icons.Material.Filled.ChevronRight" Style="font-size: 2rem;" /></button>
+                    <div class="row row-cols-4">
+                        <div class="col">
+                            <button @onclick="PrevWord" type="button"><MudIcon Icon="@Icons.Material.Filled.ChevronLeft" Style="font-size: 2rem;" />Prev</button>
+                        </div>
+                        <div class="col-6">
+                            <button @onclick="ToggleCard" type="button"><MudIcon Icon="@Icons.Material.TwoTone.ArrowCircleLeft" Style="font-size: 2rem;" />&nbsp Press to see word</button>
+                        </div>
+                        <div class="col">
+                            <button @onclick="NextWord" type="button">Next<MudIcon Icon="@Icons.Material.Filled.ChevronRight" Style="font-size: 2rem;" /></button>
+                        </div>
+                    </div>
                 </div>
             }
         </div>
@@ -79,6 +88,14 @@
         if (wordMeanings is not null && wordMeanings.Count > 0)
         {
             currentIndex = (currentIndex + 1) % wordMeanings.Count;
+        }
+    }
+    private void PrevWord()
+    {
+        showDefinition = false;
+        if (wordMeanings is not null && currentIndex != 0 && wordMeanings.Count > 0)
+        {
+            currentIndex = (currentIndex - 1) % wordMeanings.Count;
         }
     }
 

--- a/IELTS/Components/Pages/WordMeaningPages/Create.razor
+++ b/IELTS/Components/Pages/WordMeaningPages/Create.razor
@@ -11,7 +11,7 @@
 <h2>WordMeaning</h2>
 <hr />
 <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-7">
         <EditForm method="post" Model="WordMeaning" OnValidSubmit="AddWordMeaning" FormName="create" Enhance>
             <DataAnnotationsValidator />
             <ValidationSummary class="text-danger" role="alert"/>

--- a/IELTS/Components/Pages/WordMeaningPages/Index.razor
+++ b/IELTS/Components/Pages/WordMeaningPages/Index.razor
@@ -2,18 +2,13 @@
 @using Microsoft.EntityFrameworkCore
 @using IELTS.EntityModels.Models
 @using IELTS.EntityModels
+@using MudBlazor
 @implements IAsyncDisposable
 @inject IDbContextFactory<IELTS.EntityModels.IELTSStoreDbContext> DbFactory
 
 <PageTitle>Index</PageTitle>
 
-<h1>Index</h1>
-
-<p>
-    <a href="wordmeanings/create">Create New</a>
-</p>
-
-@using MudBlazor
+<h1>Word Meaning</h1>
 
 <MudDataGrid Items="context.WordMeanings">
     <Columns>


### PR DESCRIPTION
Update UI layout and navigation in word meaning components

- Adjusted card dimensions and button layout in Vocabulary.razor.
- Added PrevWord method for navigating to the previous word.
- Increased form column width in Create.razor for better spacing.
- Changed header from "Index" to "Word Meaning" in Index.razor and removed the create link.